### PR TITLE
Két kisebb fix

### DIFF
--- a/packages/idokep/idokep_multiscrape.yaml
+++ b/packages/idokep/idokep_multiscrape.yaml
@@ -235,8 +235,6 @@ multiscrape:
         select: "#topalertbar > a:nth-child(1)"
         on_error:
           log: false
-          value: default
-          default: ""
 
       - unique_id: idokep_daily_data
         name: "Időkép, napi előrejelzés adatok"
@@ -571,7 +569,7 @@ multiscrape:
 
   - resource: https://www.idokep.hu/elorejelzes/T%C3%B6r%C3%B6kb%C3%A1lint
     scan_interval: 900 # 15 percenként, hogy ne bombázzuk az oldalt
-    log_response: true
+    #log_response: true # debugoláshoz a config/multiscrape mappába menti a legutóbbi lekért HTML-t
     sensor:
       - unique_id: idokep_forecast
         name: "Időkép, előrejelzés"


### PR DESCRIPTION
Hali,

Két kisebb javítást tolnék az utolsó commithoz.

- Az előrejelzésnél a log bekapcsolva maradt
- Az idokep_alert-nél az on_error eddig unavailable-t adott ha nem volt figyelmeztetés, amire a templateben lehet megjelenési feltételt állítani. Most üres string van, erre nem. Jobb lenne ha maradna, ahogy eddig is volt, vagyis unavailable ha nem elérhető.

Köszi.